### PR TITLE
Force this.skillId to be a string from the start.

### DIFF
--- a/skills-kit-library/skills-kit-2.0.js
+++ b/skills-kit-library/skills-kit-2.0.js
@@ -130,7 +130,7 @@ const SkillsErrorEnum = {
 function FilesReader(body) {
     const eventBody = JSON.parse(body);
     this.requestId = eventBody.id;
-    this.skillId = eventBody.skill.id;
+    this.skillId = `${eventBody.skill.id}`;
     this.fileId = eventBody.source.id;
     this.fileName = eventBody.source.name;
     this.fileSize = eventBody.source.size;


### PR DESCRIPTION
`this.skillID` does not stay constant as a string between FilesReader and SkillsWriter when run on a Node.js Express server. This fix makes skillId to be a string from the get go. 